### PR TITLE
[llm] Add Claude Code plugin + marketplace prototype (xwiki-core)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "xwiki-dev-tools",
+  "owner": {
+    "name": "XWiki Development Team",
+    "url": "https://github.com/xwiki/xwiki-dev-tools"
+  },
+  "metadata": {
+    "description": "Claude Code plugins for XWiki org repos",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "xwiki-core",
+      "source": "./llm/xwiki-core",
+      "description": "Org-wide XWiki conventions, MCP servers and dev skills for all xwiki GitHub org repos",
+      "version": "0.1.0",
+      "author": {
+        "name": "XWiki Development Team"
+      }
+    }
+  ]
+}

--- a/llm/README.md
+++ b/llm/README.md
@@ -1,0 +1,46 @@
+# LLM tooling (Claude Code marketplace)
+
+This subproject distributes shared LLM configuration for XWiki org repositories as a
+[Claude Code plugin marketplace](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces).
+The marketplace manifest lives at the repository root (`/.claude-plugin/marketplace.json`); the
+plugins themselves live here under `llm/`.
+
+## Plugins
+
+| Plugin       | Scope                                                                       |
+|--------------|-----------------------------------------------------------------------------|
+| `xwiki-core` | Org-wide conventions, MCP servers and dev skills for all xwiki org repos     |
+
+### `xwiki-core` contents
+
+- **Org conventions** (`instructions/xwiki-org.md`) — injected into every session via a
+  `SessionStart` hook, **scoped by git remote** so it only applies inside `xwiki/*` and
+  `xwiki-contrib/*` repos (never in personal projects). This is the shared "CLAUDE.md equivalent".
+- **MCP servers** (`.mcp.json`) — `discourse` (forum.xwiki.org) and `sonarqube` (SonarCloud).
+  `SONARQUBE_TOKEN` and `SONARQUBE_PROJECT_KEY` are read from the environment; no secrets are
+  committed. The project key is repo-specific — set it per repo (or override in a repo-level
+  `.mcp.json`).
+- **Skills** (`skills/`) — e.g. `xwiki-build` (canonical Maven build/test commands).
+
+The hook is written in Node (`.mjs`), which ships with Claude Code, so it runs on Windows, macOS
+and Linux without a bash or `jq` dependency.
+
+## Install
+
+```
+/plugin marketplace add https://github.com/xwiki/xwiki-dev-tools
+/plugin install xwiki-core@xwiki-dev-tools
+```
+
+For local development against a checkout:
+
+```
+/plugin marketplace add /path/to/xwiki-dev-tools
+/plugin install xwiki-core@xwiki-dev-tools
+```
+
+## Validate
+
+```
+claude plugin validate ./llm/xwiki-core
+```

--- a/llm/xwiki-core/.claude-plugin/plugin.json
+++ b/llm/xwiki-core/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "xwiki-core",
+  "description": "Org-wide XWiki conventions, MCP servers and dev skills for all xwiki GitHub org repos",
+  "version": "0.1.0",
+  "author": {
+    "name": "XWiki Development Team",
+    "url": "https://xwiki.org"
+  }
+}

--- a/llm/xwiki-core/.mcp.json
+++ b/llm/xwiki-core/.mcp.json
@@ -1,0 +1,30 @@
+{
+  "mcpServers": {
+    "discourse": {
+      "command": "npx",
+      "args": ["-y", "@discourse/mcp@latest", "--site", "https://forum.xwiki.org"]
+    },
+    "sonarqube": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm", "--pull=always",
+        "-e", "SONARQUBE_URL",
+        "-e", "SONARQUBE_TOKEN",
+        "-e", "SONARQUBE_ORG",
+        "-e", "SONARQUBE_PROJECT_KEY",
+        "-e", "SONARQUBE_TOOLSETS",
+        "-e", "SONARQUBE_ADVANCED_ANALYSIS_ENABLED",
+        "-v", "${PWD}:/app/mcp-workspace:rw",
+        "mcp/sonarqube"
+      ],
+      "env": {
+        "SONARQUBE_URL": "https://sonarcloud.io",
+        "SONARQUBE_TOKEN": "${SONARQUBE_TOKEN}",
+        "SONARQUBE_ORG": "xwiki",
+        "SONARQUBE_PROJECT_KEY": "${SONARQUBE_PROJECT_KEY}",
+        "SONARQUBE_TOOLSETS": "cag,projects,analysis,issues",
+        "SONARQUBE_ADVANCED_ANALYSIS_ENABLED": "true"
+      }
+    }
+  }
+}

--- a/llm/xwiki-core/hooks/hooks.json
+++ b/llm/xwiki-core/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/inject-org-instructions.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/llm/xwiki-core/instructions/xwiki-org.md
+++ b/llm/xwiki-core/instructions/xwiki-org.md
@@ -1,0 +1,33 @@
+# XWiki org-wide conventions
+
+These conventions apply to every repository in the `xwiki` and `xwiki-contrib` GitHub
+organizations. They are injected automatically at the start of each session by the `xwiki-core`
+plugin. Repo-specific `CLAUDE.md` files add to (and may override) what follows.
+
+## Project facts
+
+- **Issue tracker:** https://jira.xwiki.org (NOT GitHub Issues). Reference issues by their JIRA key
+  (e.g. `XWIKI-12345`).
+- **Dev guide:** https://dev.xwiki.org/xwiki/bin/view/Community/
+- **CI:** https://ci.xwiki.org — build scans on Develocity at https://ge.xwiki.org/scans
+- XWiki Commons, XWiki Rendering and XWiki Platform share the **same version** at any given time.
+
+## Commit messages
+
+- Prefix the summary with the JIRA issue key when there is one: `XWIKI-12345: <summary>`.
+- Use `[Misc]` as the prefix for changes that have no associated issue.
+
+## Build (Maven)
+
+- Almost always enable the `legacy` profile. Common snapshot build:
+  `mvn clean install -Plegacy,integration-tests,snapshot`
+- Skip slow checks while iterating:
+  `-Dxwiki.checkstyle.skip=true -Dxwiki.surefire.captureconsole.skip=true -Dxwiki.revapi.skip=true`
+- Use `-DskipITs` to skip integration tests, `-DskipTests` to skip all tests.
+
+## Code conventions
+
+- Avoid adding new code to `xwiki-platform-oldcore` (`com.xpn.xwiki.*`); prefer a feature module.
+- Use the XWiki Component system (`@Component`, `@Inject`, `@Role`) rather than `XWikiContext`
+  in new code.
+- `-legacy` modules only re-export deprecated APIs — never add new logic there.

--- a/llm/xwiki-core/scripts/inject-org-instructions.mjs
+++ b/llm/xwiki-core/scripts/inject-org-instructions.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// SessionStart hook for the xwiki-core plugin.
+// Injects org-wide XWiki conventions as additionalContext, but ONLY when the current repo
+// belongs to the `xwiki` or `xwiki-contrib` GitHub org. Personal repos get nothing.
+// Written in Node (which Claude Code requires) so it works on Windows, macOS and Linux.
+
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+
+// Resolve the repo's origin remote. If this isn't a git repo, inject nothing.
+let remote = "";
+try {
+  remote = execFileSync("git", ["-C", projectDir, "remote", "get-url", "origin"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"]
+  }).trim();
+} catch {
+  process.exit(0);
+}
+
+// Scope: only xwiki/* and xwiki-contrib/* repos (handles both SSH and HTTPS remotes).
+if (!/github\.com[:/](xwiki|xwiki-contrib)\//.test(remote)) {
+  process.exit(0);
+}
+
+let text;
+try {
+  text = readFileSync(`${pluginRoot}/instructions/xwiki-org.md`, "utf8");
+} catch {
+  process.exit(0);
+}
+
+process.stdout.write(
+  JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: text
+    }
+  })
+);

--- a/llm/xwiki-core/skills/xwiki-build/SKILL.md
+++ b/llm/xwiki-core/skills/xwiki-build/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: xwiki-build
+description: Build and test XWiki Maven modules. Use when building XWiki, running its tests, or when the user mentions mvn, a build, a failing test, or a specific XWiki module.
+---
+
+# Building and testing XWiki
+
+XWiki is a multi-module Maven project. Almost every build needs the `legacy` profile.
+
+## Full build (no integration tests, fast)
+
+```bash
+mvn clean install -Plegacy,integration-tests,snapshot \
+  -Dxwiki.checkstyle.skip=true -Dxwiki.surefire.captureconsole.skip=true \
+  -Dxwiki.revapi.skip=true -DskipITs
+```
+
+Drop `-DskipITs` to include integration tests. Add `-DskipTests` to skip all tests.
+
+## Build a single module
+
+```bash
+mvn clean install -pl xwiki-platform-core/xwiki-platform-<module> -Plegacy,snapshot
+```
+
+## Run tests
+
+```bash
+# All unit tests in a module
+mvn test -pl xwiki-platform-core/xwiki-platform-<module>
+
+# A single test class
+mvn test -pl xwiki-platform-core/xwiki-platform-<module> -Dtest=MyTestClass
+
+# A single test method
+mvn test -pl xwiki-platform-core/xwiki-platform-<module> -Dtest=MyTestClass#myMethod
+
+# Integration tests
+mvn verify -pl xwiki-platform-core/xwiki-platform-<module> -Pintegration-tests
+```
+
+## Notes
+
+- The `legacy` profile activates backward-compatibility shim modules and is almost always required.
+- The `snapshot` profile enables XWiki snapshot repositories.
+- Skip flags worth knowing: `-Dxwiki.checkstyle.skip=true` (Checkstyle),
+  `-Dxwiki.revapi.skip=true` (API compat), `-Dxwiki.surefire.captureconsole.skip=true`
+  (stdout capture check).


### PR DESCRIPTION
## What this is

A **prototype** for sharing LLM / Claude Code configuration across the `xwiki` and `xwiki-contrib` GitHub orgs as a **Claude Code plugin + marketplace**, rather than the symlinks + `setup.sh` approach from the [forum thread](https://forum.xwiki.org/t/organizing-our-llm-configs-for-all-our-repos/18551). It is meant to give devs a concrete feel for what the approach could look like — not a finished setup.

## How it is structured

The repo becomes a **marketplace** (`.claude-plugin/marketplace.json` at the root), with the plugins living under `llm/`:

```
.claude-plugin/marketplace.json          ← marketplace catalog
llm/README.md
llm/xwiki-core/
├── .claude-plugin/plugin.json
├── instructions/xwiki-org.md            ← shared org-wide conventions ("CLAUDE.md for all repos")
├── hooks/hooks.json                     ← SessionStart hook wiring
├── scripts/inject-org-instructions.mjs  ← injects the conventions, scoped to xwiki org repos
├── skills/xwiki-build/SKILL.md          ← demo skill (Maven build/test commands)
└── .mcp.json                            ← discourse + sonarqube MCP servers
```

## Key design points

- **Org-wide instructions are auto-loaded every session.** A bundled `CLAUDE.md` is *not* loaded by a plugin, so the shared conventions are injected via a `SessionStart` hook that emits `additionalContext`.
- **Scoped by git remote**, not by directory layout. The hook only fires in `xwiki/*` and `xwiki-contrib/*` repos — personal projects get nothing, and there is no required `~/dev/xwiki/` directory convention.
- **Cross-platform.** The hook is written in Node (`.mjs`), which ships with Claude Code, so it works on Windows/macOS/Linux with no bash/`jq` dependency and no execute bit.
- **No committed secrets.** MCP servers use `${ENV}` expansion (e.g. `${SONARQUBE_TOKEN}`).

## Try it

```
/plugin marketplace add https://github.com/xwiki/xwiki-dev-tools
/plugin install xwiki-core@xwiki-dev-tools
```

(or point `marketplace add` at a local checkout). Then open a session in an xwiki repo and check that the conventions are injected, `/mcp` lists `discourse` + `sonarqube`, and the `xwiki-core:xwiki-build` skill is available.

## Not in scope yet

- A sibling `xwiki-contrib` plugin (looser standards) — would be a second entry in the same marketplace.
- Filling out `instructions/xwiki-org.md` and adding more skills — kept minimal on purpose.
- CODEOWNERS / contribution policy for the shared config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
